### PR TITLE
feat: Scrapper 및 ApiCaller 인터페이스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.data:spring-data-r2dbc'
+    implementation 'io.r2dbc:r2dbc-h2'
     implementation 'org.mariadb:r2dbc-mariadb'
 
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.data:spring-data-r2dbc'
     implementation 'io.r2dbc:r2dbc-h2'
     implementation 'org.mariadb:r2dbc-mariadb'
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/kaispread/grabber/application/api/ApiCaller.java
+++ b/src/main/java/com/kaispread/grabber/application/api/ApiCaller.java
@@ -1,0 +1,7 @@
+package com.kaispread.grabber.application.api;
+
+import reactor.core.publisher.Mono;
+
+public interface ApiCaller {
+    <T> Mono<T> get(final String uri, final Class<T> responseType);
+}

--- a/src/main/java/com/kaispread/grabber/application/api/SimpleApiCaller.java
+++ b/src/main/java/com/kaispread/grabber/application/api/SimpleApiCaller.java
@@ -1,0 +1,27 @@
+package com.kaispread.grabber.application.api;
+
+import com.kaispread.grabber.exception.external.ApiCallException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SimpleApiCaller implements ApiCaller {
+
+    private final WebClient webClient;
+
+    @Override
+    public <T> Mono<T> get(String uri, Class<T> responseType) {
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->  Mono.error(new ApiCallException()))
+            .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->  Mono.error(new ApiCallException()))
+            .bodyToMono(responseType);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/dto/company/CompanyDto.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/company/CompanyDto.java
@@ -1,0 +1,21 @@
+package com.kaispread.grabber.application.dto.company;
+
+import com.kaispread.grabber.domain.company.Company;
+import lombok.Builder;
+
+@Builder
+public record CompanyDto (
+    Long id,
+    String companyName,
+    String serviceName,
+    String uri
+) {
+    public static CompanyDto from(final Company company) {
+        return CompanyDto.builder()
+            .id(company.getId())
+            .companyName(company.getName())
+            .serviceName(company.getServiceName())
+            .uri(company.getRecruitmentUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/dto/error/ApiCallScrapError.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/error/ApiCallScrapError.java
@@ -1,0 +1,15 @@
+package com.kaispread.grabber.application.dto.error;
+
+import lombok.Builder;
+
+@Builder
+public record ApiCallScrapError (
+    String serviceName,
+    String url
+) implements ScrapError {
+
+    @Override
+    public String getErrorMessage() {
+        return String.format("API call Error:: Service name=%s / url=%s", serviceName, url);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/dto/error/JsonParseError.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/error/JsonParseError.java
@@ -1,0 +1,15 @@
+package com.kaispread.grabber.application.dto.error;
+
+import lombok.Builder;
+
+@Builder
+public record JsonParseError (
+    String serviceName,
+    String url
+) implements ScrapError {
+
+    @Override
+    public String getErrorMessage() {
+        return String.format("Json Parse Error:: Service name=%s / url=%s", serviceName, url);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/dto/error/ScrapError.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/error/ScrapError.java
@@ -1,0 +1,5 @@
+package com.kaispread.grabber.application.dto.error;
+
+public interface ScrapError {
+    String getErrorMessage();
+}

--- a/src/main/java/com/kaispread/grabber/application/dto/scrap/ScrapJdDto.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/scrap/ScrapJdDto.java
@@ -1,0 +1,25 @@
+package com.kaispread.grabber.application.dto.scrap;
+
+import com.kaispread.grabber.application.dto.error.ScrapError;
+import com.kaispread.grabber.domain.jd.Position;
+import lombok.Builder;
+
+@Builder
+public record ScrapJdDto (
+    String serviceName,
+    String companyName,
+    String jdId,
+    String jdUrl,
+    String jdTitle,
+    Position position,
+    String jobProcess,
+    String requiredSkill,
+    String qualification,
+    String location,
+
+    ScrapError error
+) {
+    public boolean isError() {
+        return error != null;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/DefaultHeader.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/DefaultHeader.java
@@ -1,0 +1,16 @@
+package com.kaispread.grabber.application.scrap;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public enum DefaultHeader {
+    DEFAULT(new HashMap<>());
+
+    private final Map<Object, Object> map;
+
+    DefaultHeader(Map<Object, Object> map) {
+        this.map = map;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/JobDescriptionScrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/JobDescriptionScrapper.java
@@ -1,0 +1,11 @@
+package com.kaispread.grabber.application.scrap;
+
+import com.kaispread.grabber.application.dto.company.CompanyDto;
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+public interface JobDescriptionScrapper extends Scrapper {
+    Mono<List<ScrapJdDto>> scrap(CompanyDto companyDto, Map<String, String> header);
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/Scrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/Scrapper.java
@@ -1,0 +1,4 @@
+package com.kaispread.grabber.application.scrap;
+
+public interface Scrapper {
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/ScrapperFactory.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/ScrapperFactory.java
@@ -1,0 +1,16 @@
+package com.kaispread.grabber.application.scrap;
+
+import java.util.Map;
+
+public class ScrapperFactory {
+
+    private final Map<ScrapperType, Scrapper> scrapperMap;
+
+    public ScrapperFactory(Map<ScrapperType, Scrapper> scrapperMap) {
+        this.scrapperMap = scrapperMap;
+    }
+
+    public JobDescriptionScrapper getJdScrapper(final ScrapperType type) {
+        return (JobDescriptionScrapper) scrapperMap.get(type);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/ScrapperType.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/ScrapperType.java
@@ -1,0 +1,6 @@
+package com.kaispread.grabber.application.scrap;
+
+public enum ScrapperType {
+    KAKAO_CORE
+    ;
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapper.java
@@ -1,19 +1,19 @@
 package com.kaispread.grabber.application.scrap.kakao;
 
 
+import com.kaispread.grabber.application.api.ApiCaller;
 import com.kaispread.grabber.application.dto.company.CompanyDto;
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import com.kaispread.grabber.application.scrap.JobDescriptionScrapper;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
 public class KakaoScrapper implements JobDescriptionScrapper {
 
-    private final WebClient webClient;
+    private final ApiCaller apiCaller;
 
     @Override
     public Mono<List<ScrapJdDto>> scrap(final CompanyDto companyDto, final Map<String, String> header) {

--- a/src/main/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapper.java
@@ -1,0 +1,22 @@
+package com.kaispread.grabber.application.scrap.kakao;
+
+
+import com.kaispread.grabber.application.dto.company.CompanyDto;
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.scrap.JobDescriptionScrapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class KakaoScrapper implements JobDescriptionScrapper {
+
+    private final WebClient webClient;
+
+    @Override
+    public Mono<List<ScrapJdDto>> scrap(final CompanyDto companyDto, final Map<String, String> header) {
+        return null;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/service/JdScrappingService.java
+++ b/src/main/java/com/kaispread/grabber/application/service/JdScrappingService.java
@@ -1,0 +1,20 @@
+package com.kaispread.grabber.application.service;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.scrap.ScrapperFactory;
+import com.kaispread.grabber.domain.company.CompanyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@RequiredArgsConstructor
+@Service
+public class JdScrappingService {
+
+    private ScrapperFactory scrapperFactory;
+    private CompanyRepository companyRepository;
+
+    public Flux<ScrapJdDto> runJdScrapping() {
+        return null;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/config/ApplicationConfig.java
+++ b/src/main/java/com/kaispread/grabber/config/ApplicationConfig.java
@@ -3,10 +3,12 @@ package com.kaispread.grabber.config;
 import com.kaispread.grabber.config.r2dbc.R2dbcConnectionProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 
 @EnableConfigurationProperties({
     R2dbcConnectionProperties.class
 })
+@EnableR2dbcRepositories
 @Configuration
 public class ApplicationConfig {
 

--- a/src/main/java/com/kaispread/grabber/config/bean/ScrapperBeanConfig.java
+++ b/src/main/java/com/kaispread/grabber/config/bean/ScrapperBeanConfig.java
@@ -1,0 +1,30 @@
+package com.kaispread.grabber.config.bean;
+
+import static com.kaispread.grabber.application.scrap.ScrapperType.KAKAO_CORE;
+
+import com.kaispread.grabber.application.scrap.Scrapper;
+import com.kaispread.grabber.application.scrap.ScrapperFactory;
+import com.kaispread.grabber.application.scrap.ScrapperType;
+import com.kaispread.grabber.application.scrap.kakao.KakaoScrapper;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class ScrapperBeanConfig {
+
+    @Bean
+    public ScrapperFactory scrapperFactory(WebClient webClient) {
+        Map<ScrapperType, Scrapper> scrapperMap = Map.ofEntries(
+            Map.entry(KAKAO_CORE, kakaoScrapper(webClient))
+        );
+
+        return new ScrapperFactory(scrapperMap);
+    }
+
+    @Bean
+    public Scrapper kakaoScrapper(WebClient webClient) {
+        return new KakaoScrapper(webClient);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/config/bean/ScrapperBeanConfig.java
+++ b/src/main/java/com/kaispread/grabber/config/bean/ScrapperBeanConfig.java
@@ -2,6 +2,7 @@ package com.kaispread.grabber.config.bean;
 
 import static com.kaispread.grabber.application.scrap.ScrapperType.KAKAO_CORE;
 
+import com.kaispread.grabber.application.api.ApiCaller;
 import com.kaispread.grabber.application.scrap.Scrapper;
 import com.kaispread.grabber.application.scrap.ScrapperFactory;
 import com.kaispread.grabber.application.scrap.ScrapperType;
@@ -9,22 +10,21 @@ import com.kaispread.grabber.application.scrap.kakao.KakaoScrapper;
 import java.util.Map;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class ScrapperBeanConfig {
 
     @Bean
-    public ScrapperFactory scrapperFactory(WebClient webClient) {
+    public ScrapperFactory scrapperFactory(ApiCaller apiCaller) {
         Map<ScrapperType, Scrapper> scrapperMap = Map.ofEntries(
-            Map.entry(KAKAO_CORE, kakaoScrapper(webClient))
+            Map.entry(KAKAO_CORE, kakaoScrapper(apiCaller))
         );
 
         return new ScrapperFactory(scrapperMap);
     }
 
     @Bean
-    public Scrapper kakaoScrapper(WebClient webClient) {
-        return new KakaoScrapper(webClient);
+    public Scrapper kakaoScrapper(ApiCaller apiCaller) {
+        return new KakaoScrapper(apiCaller);
     }
 }

--- a/src/main/java/com/kaispread/grabber/config/h2/H2Config.java
+++ b/src/main/java/com/kaispread/grabber/config/h2/H2Config.java
@@ -1,0 +1,32 @@
+package com.kaispread.grabber.config.h2;
+
+import java.sql.SQLException;
+import lombok.extern.slf4j.Slf4j;
+import org.h2.tools.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Profile("develop")
+@Component
+public class H2Config {
+    @Value("${spring.h2.console.port}")
+    private Integer port;
+    private Server webServer;
+
+    @EventListener(ContextRefreshedEvent.class)
+    public void start() throws SQLException {
+        log.info("start H2 database ...");
+        this.webServer = Server.createWebServer("-webPort", port.toString()).start();
+    }
+
+    @EventListener(ContextClosedEvent.class)
+    public void stop() {
+        log.info("stop H2 database ...");
+        this.webServer.stop();
+    }
+}

--- a/src/main/java/com/kaispread/grabber/config/json/JsonConfig.java
+++ b/src/main/java/com/kaispread/grabber/config/json/JsonConfig.java
@@ -1,0 +1,13 @@
+package com.kaispread.grabber.config.json;
+
+import org.json.simple.parser.JSONParser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonConfig {
+    @Bean
+    public JSONParser jsonParser() {
+        return new JSONParser();
+    }
+}

--- a/src/main/java/com/kaispread/grabber/config/r2dbc/R2dbcConfig.java
+++ b/src/main/java/com/kaispread/grabber/config/r2dbc/R2dbcConfig.java
@@ -6,11 +6,11 @@ import org.mariadb.r2dbc.MariadbConnectionConfiguration;
 import org.mariadb.r2dbc.MariadbConnectionFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
-import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 
+@Profile("!develop")
 @RequiredArgsConstructor
-@EnableR2dbcRepositories
 @Configuration
 public class R2dbcConfig extends AbstractR2dbcConfiguration {
 

--- a/src/main/java/com/kaispread/grabber/domain/company/Company.java
+++ b/src/main/java/com/kaispread/grabber/domain/company/Company.java
@@ -1,5 +1,6 @@
 package com.kaispread.grabber.domain.company;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +15,9 @@ public class Company {
     @Id
     private Long id;
 
-    private String name;
-    private String serviceName;
-    private String recruitmentUrl;
+    @NotNull private String name;
+    @NotNull private String serviceName;
+    @NotNull private String recruitmentUrl;
 
     @Builder
     public Company(String name, String serviceName, String recruitmentUrl) {

--- a/src/main/java/com/kaispread/grabber/domain/company/Company.java
+++ b/src/main/java/com/kaispread/grabber/domain/company/Company.java
@@ -1,5 +1,6 @@
 package com.kaispread.grabber.domain.company;
 
+import com.kaispread.grabber.application.scrap.ScrapperType;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,11 +19,13 @@ public class Company {
     @NotNull private String name;
     @NotNull private String serviceName;
     @NotNull private String recruitmentUrl;
+    @NotNull private ScrapperType scrapperType;
 
     @Builder
-    public Company(String name, String serviceName, String recruitmentUrl) {
+    public Company(String name, String serviceName, String recruitmentUrl, ScrapperType scrapperType) {
         this.name = name;
         this.serviceName = serviceName;
         this.recruitmentUrl = recruitmentUrl;
+        this.scrapperType = scrapperType;
     }
 }

--- a/src/main/java/com/kaispread/grabber/domain/jd/JobDescription.java
+++ b/src/main/java/com/kaispread/grabber/domain/jd/JobDescription.java
@@ -1,5 +1,6 @@
 package com.kaispread.grabber.domain.jd;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,17 +17,18 @@ public class JobDescription {
     @Id
     private Long id;
 
-    private Long companyId;
-    private String url;
-    private String jobTitle;
-    private Position jobPosition;
+    @NotNull private Long companyId;
+    @NotNull private String url;
+    @NotNull private String jobTitle;
+    @NotNull private Position jobPosition;
+    @NotNull private boolean closeFlag;
+
     private String jobProcess;
     private String requiredSkill;
     private String qualification;
     private String location;
-    private boolean closeFlag;
 
-    @CreatedDate
+    @NotNull @CreatedDate
     private LocalDateTime createdDate;
 
     @Builder

--- a/src/main/java/com/kaispread/grabber/exception/CustomException.java
+++ b/src/main/java/com/kaispread/grabber/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.kaispread.grabber.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/exception/ErrorCode.java
+++ b/src/main/java/com/kaispread/grabber/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.kaispread.grabber.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    // on API call
+    API_CALL_ERROR(500, "외부 API 호출중 문제가 발생했습니다."),
+
+    // on Scrapping (ex. json parsing ...)
+    SCRAP_ERROR(500, "Scrapping 중 문제가 발생했습니다.")
+
+    //
+    ;
+
+    private final int status;
+    private final String message;
+
+    ErrorCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/exception/external/ApiCallException.java
+++ b/src/main/java/com/kaispread/grabber/exception/external/ApiCallException.java
@@ -1,0 +1,12 @@
+package com.kaispread.grabber.exception.external;
+
+import com.kaispread.grabber.exception.CustomException;
+import com.kaispread.grabber.exception.ErrorCode;
+
+public class ApiCallException extends CustomException {
+    private static final ErrorCode errorCode = ErrorCode.API_CALL_ERROR;
+
+    public ApiCallException() {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,23 @@ spring:
     activate:
       on-profile: local
     import: classpath:/config/local/application-local-db.yml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: develop
+  r2dbc:
+    url: r2dbc:h2:mem:///testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;Mode=MySQL
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      port: 8079
+  datasource:
+    url: r2dbc:h2:mem:///testdb
+  sql:
+    init:
+      mode: always
+      schema-locations: sql/schema.sql

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS `company`
     `name`         varchar(255)             NOT NULL COMMENT '회사명',
     `service_name` varchar(255)             NOT NULL COMMENT '서비스명',
     `recruitment_url` varchar(255)          NOT NULL,
+    `scrapper_type`   varchar(100)          NOT NULL,
 
     PRIMARY KEY (id),
     UNIQUE KEY (recruitment_url)
@@ -14,6 +15,7 @@ CREATE TABLE IF NOT EXISTS `job_description`
     `id`             int                    NOT NULL AUTO_INCREMENT,
     `company_id`     int                    NOT NULL,
 
+    `job_id`         varchar(100)           NOT NULL COMMENT '각 채용 공고에 할당된 고유 ID',
     `url`            varchar(255)           NOT NULL COMMENT 'JD URL',
     `job_title`      varchar(255)           NOT NULL COMMENT '공고명',
     `job_position`   varchar(50)            NOT NULL COMMENT '포지션',
@@ -26,4 +28,4 @@ CREATE TABLE IF NOT EXISTS `job_description`
 
     PRIMARY KEY (id)
 );
-
+CREATE INDEX idx_job_id_company_id ON `job_description`(job_id, company_id);

--- a/src/test/java/com/kaispread/grabber/application/api/SimpleApiCallerTest.java
+++ b/src/test/java/com/kaispread/grabber/application/api/SimpleApiCallerTest.java
@@ -1,0 +1,27 @@
+package com.kaispread.grabber.application.api;
+
+import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class SimpleApiCallerTest extends IntegrationTestSupport {
+    @Autowired
+    private ApiCaller apiCaller;
+
+    @DisplayName("외부 API 호출에 성공한다.")
+    @Test
+    void api_call_success() {
+        // given
+        String uri = "https://careers.kakao.com/public/api/job-list?skillSet=&part=TECHNOLOGY&company=KAKAO&employeeType=";
+        Mono<String> monoResp = apiCaller.get(uri, String.class);
+
+        // when & then
+        StepVerifier.create(monoResp)
+            .expectNextMatches(Objects::nonNull)
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/kaispread/grabber/base/support/IntegrationTestSupport.java
+++ b/src/test/java/com/kaispread/grabber/base/support/IntegrationTestSupport.java
@@ -1,0 +1,7 @@
+package com.kaispread.grabber.base.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class IntegrationTestSupport {
+}

--- a/src/test/java/com/kaispread/grabber/domain/company/CompanyRepositoryTest.java
+++ b/src/test/java/com/kaispread/grabber/domain/company/CompanyRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.kaispread.grabber.domain.company;
+
+import static com.kaispread.grabber.application.scrap.ScrapperType.KAKAO_CORE;
+
+import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class CompanyRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CompanyRepository repository;
+
+    @AfterEach
+    void tearDown() {
+        repository.deleteAll().block();
+    }
+
+    @DisplayName("회사 데이터를 저장할 수 있다.")
+    @Test
+    void save() {
+        // given
+        Company company = Company.builder()
+            .name("카카오")
+            .serviceName("카카오코어")
+            .recruitmentUrl("test.url")
+            .scrapperType(KAKAO_CORE)
+            .build();
+
+        // when
+        Mono<Company> saveCompanyMono = repository.save(company);
+
+        // then
+        StepVerifier.create(saveCompanyMono)
+            .expectNextMatches(savedCompany -> savedCompany.getId() != null)
+            .verifyComplete();
+
+        Flux<Company> allCompanies = repository.findAll();
+        StepVerifier.create(allCompanies)
+            .expectNextMatches(savedCompany -> savedCompany.getName().equals("카카오"))
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Related Issue
#3 
## Description
- develop 에서는 R2dbc-H2 가 사용되도록 수정
- `company` 테이블에 scrapper 지정 필드 추가
- Scrapper 인터페이스 추가
  - 각 회사별 채용 공고 정보로부터 데이터를 스크래핑하여 Downstream으로 emit 해주는 책임을 가짐
- ApiCaller 인터페이스 추가
  - 외부 Api에 요청을 전송하여 데이터를 전달받는 책임을 가짐
  - `WebClient` 사용

## Call flow
1. Company 테이블에 저장된 url를 하나씩 사용하여 스크래핑 진행
2. 지정된 url에서 json 형식의 채용공고 데이터 추출
3. json 데이터에서 채용공고 데이터를 얻어 ScrapJdDto 형식으로 Downstream에 emit
4. `job_description` 에서 추출한 id를 in절로 삽입하여 이미 존재하는 데이터 추출
5. 이미 존재하는 데이터를 스크래핑한 데이터에서 뺌 → 아직 저장되지 않은 공고 데이터만 남음
6. 아직 저장되지 않은 공고 데이터를 데이터베이스에 삽입
7. 결과적으로 새로운 공고 데이터가 `job_description` 테이블에 저장됨