### PR TITLE
feat: MainScrapper 모듈 추가

### DIFF
--- a/src/main/java/com/kaispread/grabber/application/api/SimpleApiCaller.java
+++ b/src/main/java/com/kaispread/grabber/application/api/SimpleApiCaller.java
@@ -21,6 +21,7 @@ public class SimpleApiCaller implements ApiCaller {
             .uri(uri)
             .retrieve()
             .onStatus(HttpStatusCode::isError, clientResponse ->  Mono.error(new ApiCallException(uri)))
-            .bodyToMono(responseType);
+            .bodyToMono(responseType)
+            .onErrorResume(error -> Mono.error(new ApiCallException(uri)));
     }
 }

--- a/src/main/java/com/kaispread/grabber/application/dto/company/CompanyDto.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/company/CompanyDto.java
@@ -1,14 +1,16 @@
 package com.kaispread.grabber.application.dto.company;
 
+import com.kaispread.grabber.application.scrap.ScrapperType;
 import com.kaispread.grabber.domain.company.Company;
 import lombok.Builder;
 
 @Builder
 public record CompanyDto (
-    Long id,
+    String id,
     String companyName,
     String serviceName,
-    String uri
+    String uri,
+    ScrapperType scrapperType
 ) {
     public static CompanyDto from(final Company company) {
         return CompanyDto.builder()
@@ -16,6 +18,7 @@ public record CompanyDto (
             .companyName(company.getName())
             .serviceName(company.getServiceName())
             .uri(company.getRecruitmentUrl())
+            .scrapperType(company.getScrapperType())
             .build();
     }
 }

--- a/src/main/java/com/kaispread/grabber/application/dto/error/DefaultScrapError.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/error/DefaultScrapError.java
@@ -1,0 +1,15 @@
+package com.kaispread.grabber.application.dto.error;
+
+import lombok.Builder;
+
+@Builder
+public record DefaultScrapError(
+    String serviceName,
+    String url
+) implements ScrapError {
+
+    @Override
+    public String getErrorMessage() {
+        return String.format("Scrap Error:: Service name=%s / url=%s", serviceName, url);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/scrap/ScrapperType.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/ScrapperType.java
@@ -1,6 +1,7 @@
 package com.kaispread.grabber.application.scrap;
 
 public enum ScrapperType {
-    KAKAO_CORE
+    KAKAO_CORE,
+    HYPERCONNECT
     ;
 }

--- a/src/main/java/com/kaispread/grabber/application/scrap/core/MainScrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/core/MainScrapper.java
@@ -1,20 +1,86 @@
 package com.kaispread.grabber.application.scrap.core;
 
+import com.kaispread.grabber.application.dto.company.CompanyDto;
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.scrap.DefaultHeader;
 import com.kaispread.grabber.application.scrap.ScrapperFactory;
 import com.kaispread.grabber.domain.company.CompanyRepository;
+import com.kaispread.grabber.domain.event.ExceptionEvent;
+import com.kaispread.grabber.domain.event.ExceptionEventRepository;
+import com.kaispread.grabber.domain.jd.JobDescriptionRepository;
+import com.kaispread.grabber.exception.ContainsCompanyDataException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 
+/*
+* **MainScrapper Process**
+* 1. company 테이블에 적재된 공고 URI로부터 공고 데이터 스크랩
+*    a. 스크랩 도중 예외 발생시 exception_event 테이블에 이벤트 저장
+* 2. job_description 테이블을 조회하여 새로운 공고만 Downstream emit
+* 3. 새로운 공고 저장
+* */
+@Slf4j
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class MainScrapper {
 
-    private ScrapperFactory scrapperFactory;
-    private CompanyRepository companyRepository;
+    private static final String NEW_JOB_DESCRIPTION_LOG_FORMAT = "New Job Description has saved :: companyId = {}, position = {}, title = {}";
+    private static final String SCRAP_ERROR_LOG_FORMAT = "Scrap Error :: serviceName = {}, message = {}";
 
-    public Flux<ScrapJdDto> runJdScrapping() {
-        return null;
+    private final ScrapperFactory scrapperFactory;
+    private final CompanyRepository companyRepository;
+    private final JobDescriptionRepository jdRepository;
+    private final ExceptionEventRepository exceptionEventRepository;
+
+    public Flux<ScrapJdDto> runScrapping() {
+        return companyRepository.findAll()
+            .map(CompanyDto::from)
+            .flatMap(companyDto -> scrapperFactory.getJdScrapper(companyDto.scrapperType())
+                .scrap(companyDto, DefaultHeader.DEFAULT.getMap())
+                // 에러 이벤트 저장 및 Publisher 대체
+                .onErrorResume(ContainsCompanyDataException.class, this::getErrorScrapJdDto))
+            .filter(ScrapJdDto::isValidDto)
+            .groupBy(ScrapJdDto::companyId)
+            .flatMap(scrapJdDto -> scrapJdDto.collectList()
+                .flatMapMany(scrapJdDtoList -> filterNewJobDescription(scrapJdDtoList, scrapJdDto.key())))
+            // 새로운 공고 저장
+            .flatMap(newJdDto -> jdRepository.save(newJdDto.toJdEntity())
+                .doOnNext(savedJd -> log.info(NEW_JOB_DESCRIPTION_LOG_FORMAT, savedJd.getCompanyId(), savedJd.getJobPosition(), savedJd.getJobTitle()))
+                .thenReturn(newJdDto));
+    }
+
+    private Flux<ScrapJdDto> filterNewJobDescription(final List<ScrapJdDto> scrapJdDtoList, final String companyId) {
+        List<String> list = scrapJdDtoList.stream()
+            .map(ScrapJdDto::jdId)
+            .toList();
+
+        return jdRepository.findByCompanyIdAndJobId(companyId, list)
+            .collectList()
+            .flatMapMany(savedJdIds -> Flux.fromStream(
+                scrapJdDtoList.stream()
+                    .filter(scrapJdDto -> !savedJdIds.contains(scrapJdDto.jdId()))));
+    }
+
+    private Flux<ScrapJdDto> getErrorScrapJdDto(final ContainsCompanyDataException exception) {
+        return exceptionEventRepository.save(getExceptionEvent(exception))
+            .thenMany(
+                Flux.just(ScrapJdDto.createExceptionDto(exception))
+                    .doOnNext(errorDto -> log.warn(SCRAP_ERROR_LOG_FORMAT,
+                        exception.getCompanyData().serviceName(),
+                        errorDto.error().getErrorMessage()))
+            );
+    }
+
+    private ExceptionEvent getExceptionEvent(final ContainsCompanyDataException e) {
+        return ExceptionEvent.builder()
+            .companyId(e.getCompanyData().id())
+            .exception(e.getClass().getSimpleName())
+            .description(e.getMessage())
+            .build();
     }
 }

--- a/src/main/java/com/kaispread/grabber/application/scrap/core/MainScrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/core/MainScrapper.java
@@ -1,4 +1,4 @@
-package com.kaispread.grabber.application.service;
+package com.kaispread.grabber.application.scrap.core;
 
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import com.kaispread.grabber.application.scrap.ScrapperFactory;
@@ -9,7 +9,7 @@ import reactor.core.publisher.Flux;
 
 @RequiredArgsConstructor
 @Service
-public class JdScrappingService {
+public class MainScrapper {
 
     private ScrapperFactory scrapperFactory;
     private CompanyRepository companyRepository;

--- a/src/main/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapper.java
+++ b/src/main/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapper.java
@@ -16,7 +16,6 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class KakaoScrapper implements JobDescriptionScrapper {
 
-    private static final String JOB_URL = "https://careers.kakao.com/public/api/job-list?part=TECHNOLOGY&company=KAKAO&page=1&size=100";
     private static final String JOB_LIST_KEY = "jobList";
 
     private final ApiCaller apiCaller;
@@ -24,8 +23,7 @@ public class KakaoScrapper implements JobDescriptionScrapper {
 
     @Override
     public Flux<ScrapJdDto> scrap(final CompanyDto companyDto, final Map<String, String> header) {
-        return apiCaller.get(JOB_URL, String.class)
-            .log()
+        return apiCaller.get(companyDto.uri(), String.class)
             .onErrorResume(error -> Mono.error(new DataApiCallException(companyDto)))
             .retry(3)
             .flatMap(scrapStr -> Mono.just(parser.parseToJsonObject(scrapStr)))

--- a/src/main/java/com/kaispread/grabber/domain/company/Company.java
+++ b/src/main/java/com/kaispread/grabber/domain/company/Company.java
@@ -2,30 +2,41 @@ package com.kaispread.grabber.domain.company;
 
 import com.kaispread.grabber.application.scrap.ScrapperType;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table("company")
-public class Company {
+public class Company implements Persistable<String> {
     @Id
-    private Long id;
+    private String id;
 
     @NotNull private String name;
     @NotNull private String serviceName;
     @NotNull private String recruitmentUrl;
     @NotNull private ScrapperType scrapperType;
 
+    @CreatedDate private LocalDateTime createdDate;
+
     @Builder
-    public Company(String name, String serviceName, String recruitmentUrl, ScrapperType scrapperType) {
+    public Company(String id, String name, String serviceName, String recruitmentUrl, ScrapperType scrapperType) {
+        this.id = id;
         this.name = name;
         this.serviceName = serviceName;
         this.recruitmentUrl = recruitmentUrl;
         this.scrapperType = scrapperType;
+    }
+
+    @Override
+    public boolean isNew() {
+        return createdDate == null;
     }
 }

--- a/src/main/java/com/kaispread/grabber/domain/company/CompanyRepository.java
+++ b/src/main/java/com/kaispread/grabber/domain/company/CompanyRepository.java
@@ -2,6 +2,6 @@ package com.kaispread.grabber.domain.company;
 
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
-public interface CompanyRepository extends ReactiveCrudRepository<Company, Long> {
+public interface CompanyRepository extends ReactiveCrudRepository<Company, String> {
 
 }

--- a/src/main/java/com/kaispread/grabber/domain/event/ExceptionEvent.java
+++ b/src/main/java/com/kaispread/grabber/domain/event/ExceptionEvent.java
@@ -1,0 +1,33 @@
+package com.kaispread.grabber.domain.event;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table("exception_event")
+public class ExceptionEvent {
+    @Id
+    private Long id;
+
+    @NotNull private String companyId;
+    private String exception;
+    private String description;
+
+    @NotNull @CreatedDate
+    private LocalDateTime createdDate;
+
+    @Builder
+    public ExceptionEvent(@NotNull String companyId, String exception, String description) {
+        this.companyId = companyId;
+        this.exception = exception;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/domain/event/ExceptionEventRepository.java
+++ b/src/main/java/com/kaispread/grabber/domain/event/ExceptionEventRepository.java
@@ -1,0 +1,6 @@
+package com.kaispread.grabber.domain.event;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface ExceptionEventRepository extends ReactiveCrudRepository<ExceptionEvent, Long>  {
+}

--- a/src/main/java/com/kaispread/grabber/domain/jd/JobDescription.java
+++ b/src/main/java/com/kaispread/grabber/domain/jd/JobDescription.java
@@ -17,7 +17,7 @@ public class JobDescription {
     @Id
     private Long id;
 
-    @NotNull private Long companyId;
+    @NotNull private String companyId;
     @NotNull private String jobId;
     @NotNull private String url;
     @NotNull private String jobTitle;
@@ -34,9 +34,9 @@ public class JobDescription {
     private LocalDateTime createdDate;
 
     @Builder
-    public JobDescription(Long companyId, String jobId, String url, String jobTitle, Position jobPosition,
+    public JobDescription(String companyId, String jobId, String url, String jobTitle, Position jobPosition,
                           String jobProcess, String requiredSkill, String qualification,
-                          String location, boolean closeFlag, String introduction) {
+                          String location, String introduction) {
         this.companyId = companyId;
         this.jobId = jobId;
         this.url = url;
@@ -46,7 +46,7 @@ public class JobDescription {
         this.requiredSkill = requiredSkill;
         this.qualification = qualification;
         this.location = location;
-        this.closeFlag = closeFlag;
         this.introduction = introduction;
+        this.closeFlag = false;
     }
 }

--- a/src/main/java/com/kaispread/grabber/domain/jd/JobDescriptionRepository.java
+++ b/src/main/java/com/kaispread/grabber/domain/jd/JobDescriptionRepository.java
@@ -1,7 +1,16 @@
 package com.kaispread.grabber.domain.jd;
 
+import java.util.Collection;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 public interface JobDescriptionRepository extends ReactiveCrudRepository<JobDescription, Long> {
 
+    @Query("""
+           SELECT job_id FROM job_description
+           WHERE company_id = :companyId AND job_id IN (:jobIds)
+           """)
+    Flux<String> findByCompanyIdAndJobId(@Param("companyId") String companyId, @Param("jobIds") Collection<String> jobIds);
 }

--- a/src/main/java/com/kaispread/grabber/exception/ErrorCode.java
+++ b/src/main/java/com/kaispread/grabber/exception/ErrorCode.java
@@ -9,9 +9,10 @@ public enum ErrorCode {
 
     // on Scrapping (ex. json parsing ...)
     SCRAP_ERROR(500, "Scrapping 중 문제가 발생했습니다."),
-    PARSE_ERROR(500, "Json 인스턴스로 변환 중 문제가 발생했습니다.")
+    PARSE_ERROR(500, "Json 인스턴스로 변환 중 문제가 발생했습니다."),
 
-    //
+    // on Type Convert
+    CONVERT_JOB_DESCRIPTION(500, "JobDescription Entity로 변환하는데 실패했습니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/kaispread/grabber/exception/convert/ConvertJobDescriptionException.java
+++ b/src/main/java/com/kaispread/grabber/exception/convert/ConvertJobDescriptionException.java
@@ -1,0 +1,12 @@
+package com.kaispread.grabber.exception.convert;
+
+import com.kaispread.grabber.exception.CustomException;
+import com.kaispread.grabber.exception.ErrorCode;
+
+public class ConvertJobDescriptionException extends CustomException {
+    private static final ErrorCode errorCode = ErrorCode.CONVERT_JOB_DESCRIPTION;
+
+    public ConvertJobDescriptionException() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/presentation/ScrapperController.java
+++ b/src/main/java/com/kaispread/grabber/presentation/ScrapperController.java
@@ -1,0 +1,21 @@
+package com.kaispread.grabber.presentation;
+
+import com.kaispread.grabber.application.scrap.core.MainScrapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/scrap")
+@RestController
+public class ScrapperController {
+    private final MainScrapper mainScrapper;
+
+    @PostMapping
+    public Mono<Void> post() {
+        return mainScrapper.runScrapping()
+                           .then();
+    }
+}

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,0 +1,3 @@
+INSERT INTO `company` VALUES
+('A001', 'kakao', 'kakao talk', 'https://careers.kakao.com/public/api/job-list?part=TECHNOLOGY&company=KAKAO&page=1&size=100', 'KAKAO_CORE')
+;

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,10 +1,11 @@
 CREATE TABLE IF NOT EXISTS `company`
 (
-    `id`           integer(10)              NOT NULL AUTO_INCREMENT,
-    `name`         varchar(255)             NOT NULL COMMENT '회사명',
-    `service_name` varchar(255)             NOT NULL COMMENT '서비스명',
-    `recruitment_url` varchar(255)          NOT NULL,
-    `scrapper_type`   varchar(100)          NOT NULL,
+    `id`                char(4)                 NOT NULL COMMENT '회사 ID ex) A001',
+    `name`              varchar(255)            NOT NULL COMMENT '회사명',
+    `service_name`      varchar(255)            NOT NULL COMMENT '서비스명',
+    `recruitment_url`   varchar(255)            NOT NULL,
+    `scrapper_type`     varchar(100)            NOT NULL,
+    `created_date`      DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',
 
     PRIMARY KEY (id),
     UNIQUE KEY (recruitment_url)
@@ -13,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `company`
 CREATE TABLE IF NOT EXISTS `job_description`
 (
     `id`             int                    NOT NULL AUTO_INCREMENT,
-    `company_id`     int                    NOT NULL,
+    `company_id`     char(4)                NOT NULL,
 
     `job_id`         varchar(100)           NOT NULL COMMENT '각 채용 공고에 할당된 고유 ID',
     `url`            varchar(255)           NOT NULL COMMENT 'JD URL',
@@ -27,6 +28,18 @@ CREATE TABLE IF NOT EXISTS `job_description`
     `close_flag`     tinyint                NOT NULL COMMENT '마감 여부',
     `created_date`   DATETIME DEFAULT NOW() NOT NULL COMMENT '생성일',
 
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (company_id) REFERENCES `company`(`id`)
 );
 CREATE INDEX idx_job_id_company_id ON `job_description`(job_id, company_id);
+
+CREATE TABLE IF NOT EXISTS `exception_event`
+(
+    `id`            int                     NOT NULL AUTO_INCREMENT,
+    `company_id`    char(4)                 NOT NULL,
+    `exception`     varchar(40)             COMMENT '예외 종류',
+    `description`   varchar(255)            COMMENT '예외 설명',
+    `created_date`  DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',
+
+    PRIMARY KEY (id)
+);

--- a/src/test/java/com/kaispread/grabber/application/json/kakao/KakaoJsonParserTest.java
+++ b/src/test/java/com/kaispread/grabber/application/json/kakao/KakaoJsonParserTest.java
@@ -37,7 +37,7 @@ class KakaoJsonParserTest extends IntegrationTestSupport {
 
     private CompanyDto getCompanyDto() {
         return CompanyDto.builder()
-            .id(1L)
+            .id("A001")
             .companyName("카카오")
             .serviceName("카카오 코어")
             .build();

--- a/src/test/java/com/kaispread/grabber/application/scrap/core/MainScrapperTest.java
+++ b/src/test/java/com/kaispread/grabber/application/scrap/core/MainScrapperTest.java
@@ -1,0 +1,190 @@
+package com.kaispread.grabber.application.scrap.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.kaispread.grabber.application.dto.company.CompanyDto;
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.scrap.JobDescriptionScrapper;
+import com.kaispread.grabber.application.scrap.ScrapperFactory;
+import com.kaispread.grabber.application.scrap.ScrapperType;
+import com.kaispread.grabber.domain.company.Company;
+import com.kaispread.grabber.domain.company.CompanyRepository;
+import com.kaispread.grabber.domain.event.ExceptionEvent;
+import com.kaispread.grabber.domain.event.ExceptionEventRepository;
+import com.kaispread.grabber.domain.jd.JobDescription;
+import com.kaispread.grabber.domain.jd.JobDescriptionRepository;
+import com.kaispread.grabber.domain.jd.Position;
+import com.kaispread.grabber.exception.external.DataApiCallException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class MainScrapperTest {
+
+    @Mock private ScrapperFactory scrapperFactory;
+    @Mock private JobDescriptionRepository jdRepository;
+    @Mock private CompanyRepository companyRepository;
+    @Mock private ExceptionEventRepository exceptionEventRepository;
+
+    @InjectMocks
+    private MainScrapper mainScrapper;
+
+    @DisplayName("새로운 공고와 예외 이벤트가 각각 저장된다.")
+    @Test
+    void save_new_jd_and_exception_event() {
+        // given
+        given(scrapperFactory.getJdScrapper(any()))
+            .willReturn(new MockJdAndErrorScrapper());
+        given(companyRepository.findAll())
+            .willReturn(getMockCompany());
+        given(exceptionEventRepository.save(any()))
+            .willReturn(Mono.just(ExceptionEvent.builder().build()));
+        given(jdRepository.save(any()))
+            .willReturn(Mono.just(JobDescription.builder().build()));
+        given(jdRepository.findByCompanyIdAndJobId(any(), any()))
+            .willReturn(Flux.empty());
+
+        // when
+        Flux<ScrapJdDto> scrapJdDtoFlux = mainScrapper.runScrapping();
+
+        // then
+        StepVerifier.create(scrapJdDtoFlux)
+            .expectNextMatches(scrapJdDto -> scrapJdDto.jdId().equals("JE0001"))
+            .verifyComplete();
+
+        verify(exceptionEventRepository, times(1)).save(any());
+        verify(jdRepository, times(1)).save(any());
+    }
+
+    @DisplayName("새로운 공고 데이터만 저장된다.")
+    @Test
+    void save_success_scrap_exception() {
+        // given
+        final List<String> expectJdIdList = new ArrayList<>(List.of("KA0002", "H0001", "H0002"));
+
+        given(scrapperFactory.getJdScrapper(any()))
+            .willReturn(new MockJdScrapper());
+        given(companyRepository.findAll())
+            .willReturn(getMockCompany());
+        given(jdRepository.save(any()))
+            .willReturn(Mono.just(JobDescription.builder().build()));
+
+        given(jdRepository.findByCompanyIdAndJobId(eq("A001"), anyList()))
+            .willReturn(Flux.just("KA0001"));
+        given(jdRepository.findByCompanyIdAndJobId(eq("A002"), anyList()))
+            .willReturn(Flux.empty());
+
+        // when
+        Flux<ScrapJdDto> scrapJdDtoFlux = mainScrapper.runScrapping();
+
+        // then
+        StepVerifier.create(scrapJdDtoFlux)
+            .thenConsumeWhile(scrapJdDto -> expectJdIdList.remove(scrapJdDto.jdId()))
+            .verifyComplete();
+
+        assertThat(expectJdIdList).isEmpty();
+        verify(exceptionEventRepository, times(0)).save(any());
+        verify(jdRepository, times(3)).save(any());
+    }
+
+    private Flux<Company> getMockCompany() {
+        return Flux.just(
+            Company.builder()
+                .id("A001")
+                .name("kakao core")
+                .serviceName("kakao talk")
+                .recruitmentUrl("https://mock.kakao.core")
+                .scrapperType(ScrapperType.KAKAO_CORE)
+                .build(),
+            Company.builder()
+                .id("A002")
+                .name("hyper connect")
+                .serviceName("Azar")
+                .recruitmentUrl("https://mock.hyperconnet.core")
+                .scrapperType(ScrapperType.HYPERCONNECT)
+                .build()
+        );
+    }
+
+    static class MockJdAndErrorScrapper implements JobDescriptionScrapper {
+        @Override
+        public Flux<ScrapJdDto> scrap(CompanyDto companyDto, Map<String, String> header) {
+            if (companyDto.scrapperType() == ScrapperType.KAKAO_CORE)
+                return Flux.error(new DataApiCallException(companyDto));
+
+            return Flux.just(ScrapJdDto.builder()
+                    .companyId("A002")
+                    .jdId("JE0001")
+                    .jdUrl("https://mock.jd.1")
+                    .jdTitle("Hakuna Backend Developer")
+                    .position(Position.BACKEND)
+                    .serviceName("Hakuna")
+                    .companyName("hyper connect")
+                .build());
+        }
+    }
+
+    static class MockJdScrapper implements JobDescriptionScrapper {
+        @Override
+        public Flux<ScrapJdDto> scrap(CompanyDto companyDto, Map<String, String> header) {
+            if (companyDto.scrapperType() == ScrapperType.KAKAO_CORE)
+                return Flux.just(
+                    ScrapJdDto.builder()
+                        .companyId("A001")
+                        .jdId("KA0001")
+                        .jdUrl("https://mock.jd.1")
+                        .jdTitle("백엔드 개발자")
+                        .position(Position.BACKEND)
+                        .serviceName("kakao core")
+                        .companyName("kakao")
+                        .build(),
+                    ScrapJdDto.builder()
+                        .companyId("A001")
+                        .jdId("KA0002")
+                        .jdUrl("https://mock.jd.2")
+                        .jdTitle("프론트엔드 개발자")
+                        .position(Position.FRONTEND)
+                        .serviceName("kakao core")
+                        .companyName("kakao")
+                        .build()
+                );
+
+            return Flux.just(
+                ScrapJdDto.builder()
+                    .companyId("A002")
+                    .jdId("H0001")
+                    .jdUrl("https://mock.ha.1")
+                    .jdTitle("백엔드 개발자")
+                    .position(Position.BACKEND)
+                    .serviceName("Hakuna")
+                    .companyName("hyperconnect")
+                    .build(),
+                ScrapJdDto.builder()
+                    .companyId("A001")
+                    .jdId("H0002")
+                    .jdUrl("https://mock.ha.2")
+                    .jdTitle("프론트엔드 개발자")
+                    .position(Position.FRONTEND)
+                    .serviceName("Azar")
+                    .companyName("hyperconnect")
+                    .build()
+            );
+        }
+    }
+}

--- a/src/test/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapperMockTest.java
+++ b/src/test/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapperMockTest.java
@@ -9,6 +9,7 @@ import com.kaispread.grabber.application.api.ApiCaller;
 import com.kaispread.grabber.application.dto.company.CompanyDto;
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import com.kaispread.grabber.application.json.kakao.KakaoJsonParser;
+import com.kaispread.grabber.exception.ContainsCompanyDataException;
 import com.kaispread.grabber.exception.external.ApiCallException;
 import com.kaispread.grabber.exception.external.DataApiCallException;
 import com.kaispread.grabber.exception.json.DataJsonException;
@@ -119,19 +120,13 @@ class KakaoScrapperMockTest {
 
     private CompanyDto getCompanyDto() {
         return CompanyDto.builder()
-            .id(1L)
+            .id("A001")
             .companyName("카카오")
             .serviceName("카카오 코어")
             .build();
     }
 
-    private Flux<ScrapJdDto> getErrorScrapJdDto(final DataApiCallException exception) {
-        CompanyDto companyDto = exception.getCompanyData();
-        return Flux.just(ScrapJdDto.createApiExceptionDto(companyDto.serviceName(), companyDto.uri()));
-    }
-
-    private Flux<ScrapJdDto> getErrorScrapJdDto(final DataJsonException exception) {
-        CompanyDto companyDto = exception.getCompanyData();
-        return Flux.just(ScrapJdDto.createApiExceptionDto(companyDto.serviceName(), companyDto.uri()));
+    private Flux<ScrapJdDto> getErrorScrapJdDto(final ContainsCompanyDataException exception) {
+        return Flux.just(ScrapJdDto.createExceptionDto(exception));
     }
 }

--- a/src/test/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapperTest.java
+++ b/src/test/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapperTest.java
@@ -6,6 +6,7 @@ import com.kaispread.grabber.application.dto.company.CompanyDto;
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import com.kaispread.grabber.application.scrap.JobDescriptionScrapper;
 import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import com.kaispread.grabber.domain.company.CompanyRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,9 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 class KakaoScrapperTest extends IntegrationTestSupport {
+
+    @Autowired
+    CompanyRepository companyRepository;
 
     @Autowired
     JobDescriptionScrapper kakaoScrapper;
@@ -33,9 +37,10 @@ class KakaoScrapperTest extends IntegrationTestSupport {
 
     private CompanyDto getCompanyDto() {
         return CompanyDto.builder()
-            .id("A0001")
-            .companyName("카카오")
-            .serviceName("카카오 코어")
+            .id("A001")
+            .companyName("kakao")
+            .serviceName("kakao talk")
+            .uri("https://careers.kakao.com/public/api/job-list?part=TECHNOLOGY&company=KAKAO&page=1&size=100")
             .build();
     }
 }

--- a/src/test/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapperTest.java
+++ b/src/test/java/com/kaispread/grabber/application/scrap/kakao/KakaoScrapperTest.java
@@ -33,7 +33,7 @@ class KakaoScrapperTest extends IntegrationTestSupport {
 
     private CompanyDto getCompanyDto() {
         return CompanyDto.builder()
-            .id(1L)
+            .id("A0001")
             .companyName("카카오")
             .serviceName("카카오 코어")
             .build();

--- a/src/test/java/com/kaispread/grabber/domain/company/CompanyRepositoryTest.java
+++ b/src/test/java/com/kaispread/grabber/domain/company/CompanyRepositoryTest.java
@@ -26,6 +26,7 @@ class CompanyRepositoryTest extends IntegrationTestSupport {
     void save() {
         // given
         Company company = Company.builder()
+            .id("A001")
             .name("카카오")
             .serviceName("카카오코어")
             .recruitmentUrl("test.url")

--- a/src/test/java/com/kaispread/grabber/domain/jd/JobDescriptionRepositoryTest.java
+++ b/src/test/java/com/kaispread/grabber/domain/jd/JobDescriptionRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.kaispread.grabber.domain.jd;
+
+import com.kaispread.grabber.application.scrap.ScrapperType;
+import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import com.kaispread.grabber.domain.company.Company;
+import com.kaispread.grabber.domain.company.CompanyRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class JobDescriptionRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private JobDescriptionRepository jdRepository;
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @AfterEach
+    void tearDown() {
+        jdRepository.deleteAll().block();
+        companyRepository.deleteAll().block();
+    }
+
+    @DisplayName("이미 존재하는 공고의 job_id 를 조회할 수 있다.")
+    @Test
+    void findByCompanyIdAndJobId() {
+        // given
+        saveCompany().block();
+        saveJdList().collectList().block();
+
+        // when
+        Flux<String> findFlux = jdRepository.findByCompanyIdAndJobId("A001", List.of("KA002", "KA003", "KA004"));
+
+        // then
+        StepVerifier.create(findFlux)
+            .expectNextMatches("KA002"::equals)
+            .expectNextMatches("KA003"::equals)
+            .verifyComplete();
+    }
+
+    private Mono<Company> saveCompany() {
+        return companyRepository.save(Company.builder()
+                .id("A001")
+                .name("kakao")
+                .serviceName("kakao core")
+                .recruitmentUrl("mock.url")
+                .scrapperType(ScrapperType.KAKAO_CORE)
+                .build());
+    }
+
+    private Flux<JobDescription> saveJdList() {
+        return jdRepository.saveAll(List.of(
+            JobDescription.builder()
+                .companyId("A001")
+                .jobId("KA001")
+                .url("mock.url.1")
+                .jobTitle("Backend")
+                .jobPosition(Position.BACKEND)
+                .build(),
+            JobDescription.builder()
+                .companyId("A001")
+                .jobId("KA002")
+                .url("mock.url.2")
+                .jobTitle("Frontend")
+                .jobPosition(Position.FRONTEND)
+                .build(),
+            JobDescription.builder()
+                .companyId("A001")
+                .jobId("KA003")
+                .url("mock.url.3")
+                .jobTitle("Devops")
+                .jobPosition(Position.DEVOPS)
+                .build()
+        ));
+    }
+}

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -1,10 +1,11 @@
 CREATE TABLE IF NOT EXISTS `company`
 (
-    `id`           integer(10)              NOT NULL AUTO_INCREMENT,
-    `name`         varchar(255)             NOT NULL COMMENT '회사명',
-    `service_name` varchar(255)             NOT NULL COMMENT '서비스명',
-    `recruitment_url` varchar(255)          NOT NULL,
-    `scrapper_type`   varchar(100)          NOT NULL,
+    `id`                char(4)                 NOT NULL COMMENT '회사 ID ex) A001',
+    `name`              varchar(255)            NOT NULL COMMENT '회사명',
+    `service_name`      varchar(255)            NOT NULL COMMENT '서비스명',
+    `recruitment_url`   varchar(255)            NOT NULL,
+    `scrapper_type`     varchar(100)            NOT NULL,
+    `created_date`      DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',
 
     PRIMARY KEY (id),
     UNIQUE KEY (recruitment_url)
@@ -13,19 +14,32 @@ CREATE TABLE IF NOT EXISTS `company`
 CREATE TABLE IF NOT EXISTS `job_description`
 (
     `id`             int                    NOT NULL AUTO_INCREMENT,
-    `company_id`     int                    NOT NULL,
+    `company_id`     char(4)                NOT NULL,
 
     `job_id`         varchar(100)           NOT NULL COMMENT '각 채용 공고에 할당된 고유 ID',
     `url`            varchar(255)           NOT NULL COMMENT 'JD URL',
     `job_title`      varchar(255)           NOT NULL COMMENT '공고명',
     `job_position`   varchar(50)            NOT NULL COMMENT '포지션',
     `job_process`    varchar(100)           COMMENT '채용 절차',
+    `introduction`   TEXT                   COMMENT '직무 소개',
     `required_skill` varchar(255)           COMMENT '필요 스킬',
-    `qualification`  varchar(255)           COMMENT '자격/우대 사항',
+    `qualification`  TEXT                   COMMENT '자격/우대 사항',
     `location`       varchar(100)           COMMENT '위치',
     `close_flag`     tinyint                NOT NULL COMMENT '마감 여부',
     `created_date`   DATETIME DEFAULT NOW() NOT NULL COMMENT '생성일',
 
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (company_id) REFERENCES `company`(`id`)
 );
 CREATE INDEX idx_job_id_company_id ON `job_description`(job_id, company_id);
+
+CREATE TABLE IF NOT EXISTS `exception_event`
+(
+    `id`            int                     NOT NULL AUTO_INCREMENT,
+    `company_id`    char(4)                 NOT NULL,
+    `exception`     varchar(40)             COMMENT '예외 종류',
+    `description`   varchar(255)            COMMENT '예외 설명',
+    `created_date`  DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',
+
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
## Related Issue
#8 

## Description
- MainScrapper 모듈 추가
  - 1. company 테이블에 적재된 공고 URI로부터 공고 데이터 스크랩
    - 스크랩 도중 예외 발생시 exception_event 테이블에 이벤트 저장
  - 2. job_description 테이블을 조회하여 새로운 공고만 Downstream emit
  - 3. 새로운 공고 저장
- exception_event 테이블 및 Entity 추가
- Scrap Trigger 용 Controller 추가
  - url -> `POST /v1/scrap`
- 테스트 코드 추가

## Tasks not included in this PR
- Slack 연동

## What to do in the future
- Slack 연동
- 스케줄러 추가
- 다른 채용 공고 Scrapper 추가
