### PR TITLE
feat: 예외 메시지 생성 기능 추가

### DIFF
--- a/src/main/java/com/kaispread/grabber/GrabberApplication.java
+++ b/src/main/java/com/kaispread/grabber/GrabberApplication.java
@@ -1,5 +1,7 @@
 package com.kaispread.grabber;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -10,4 +12,9 @@ public class GrabberApplication {
         SpringApplication.run(GrabberApplication.class, args);
     }
 
+    @PostConstruct
+    public void init() {
+        // Timezone setting
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }

--- a/src/main/java/com/kaispread/grabber/application/dto/company/CompanyDto.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/company/CompanyDto.java
@@ -9,6 +9,7 @@ public record CompanyDto (
     String id,
     String companyName,
     String serviceName,
+    String serviceNameKr,
     String uri,
     ScrapperType scrapperType
 ) {
@@ -17,6 +18,7 @@ public record CompanyDto (
             .id(company.getId())
             .companyName(company.getName())
             .serviceName(company.getServiceName())
+            .serviceNameKr(company.getServiceNameKr())
             .uri(company.getRecruitmentUrl())
             .scrapperType(company.getScrapperType())
             .build();

--- a/src/main/java/com/kaispread/grabber/application/dto/scrap/ScrapJdDto.java
+++ b/src/main/java/com/kaispread/grabber/application/dto/scrap/ScrapJdDto.java
@@ -23,6 +23,7 @@ public record ScrapJdDto (
     @NotNull String jdTitle,
     @NotNull Position position,
     @NotNull String serviceName,
+    @NotNull String serviceNameKr,
 
     String companyName,
     String jobProcess,

--- a/src/main/java/com/kaispread/grabber/application/json/kakao/KakaoJsonParser.java
+++ b/src/main/java/com/kaispread/grabber/application/json/kakao/KakaoJsonParser.java
@@ -41,6 +41,7 @@ public class KakaoJsonParser extends CustomJsonParser {
         return ScrapJdDto.builder()
             .companyId(companyDto.id())
             .serviceName(companyDto.serviceName())
+            .serviceNameKr(companyDto.serviceNameKr())
             .companyName(companyDto.companyName())
             .jdId(jobId)
             .jdUrl(String.format(URL_FORMAT, jobId))

--- a/src/main/java/com/kaispread/grabber/application/message/DailyJdMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/DailyJdMessageGenerator.java
@@ -1,0 +1,27 @@
+package com.kaispread.grabber.application.message;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.slack.SlackChannel;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+public class DailyJdMessageGenerator extends JdMessageGenerator implements NewEventMessageGenerator {
+
+    private static final SlackChannel CHANNEL = SlackChannel.DAILY_ALL;
+
+    @Override
+    public Mono<String> generateMessage(Flux<ScrapJdDto> scrapJdDtoFlux) {
+        return scrapJdDtoFlux
+            .groupBy(ScrapJdDto::companyName)
+            .flatMap(groupedFlux -> groupedFlux
+                .collectList()
+                .map(list -> getMessagePerService(groupedFlux.key(), list))
+            )
+            .collectList()
+            .filter(list -> !list.isEmpty())
+            .switchIfEmpty(getNoEventMessage())
+            .map(messagePerCompany -> getTotalMessage(CHANNEL.getChannelName(), messagePerCompany));
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/message/ExceptionEventMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/ExceptionEventMessageGenerator.java
@@ -1,0 +1,76 @@
+package com.kaispread.grabber.application.message;
+
+import com.kaispread.grabber.domain.company.Company;
+import com.kaispread.grabber.domain.company.CompanyRepository;
+import com.kaispread.grabber.domain.event.ExceptionEvent;
+import com.kaispread.grabber.domain.event.ExceptionEventRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Component
+public class ExceptionEventMessageGenerator {
+
+    private static final String HEAD_LINE = "[%s 예외 발생 현황]";
+    private static final String NO_EVENT = "* 아무 예외가 발생하지 않았습니다 *";
+    private static final String EXCEPTION_MESSAGE_FORMAT = "* %s * \n url = %s \n exception = %s \n description = %s";
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("M월 d일");
+
+    private final ExceptionEventRepository exceptionEventRepository;
+    private final CompanyRepository companyRepository;
+
+    public Mono<String> generateExceptionMessage() {
+        LocalDate findDate = LocalDate.now();
+
+        return exceptionEventRepository.findByCreatedDate(findDate)
+            .flatMap(exceptionEvent ->
+                companyRepository.findById(exceptionEvent.getCompanyId())
+                    .map(company -> ExceptionCompanyDto.of(exceptionEvent, company)))
+            .map(this::getExceptionMessage)
+            .collectList()
+            .filter(list -> !list.isEmpty())
+            .switchIfEmpty(getNoEventMessage())
+            .map(this::getTotalMessage);
+    }
+
+    private String getHeadLine() {
+        String todayDate = LocalDate.now().format(DATE_FORMAT);
+        return String.format(HEAD_LINE, todayDate);
+    }
+
+    private String getExceptionMessage(final ExceptionCompanyDto dto) {
+        return String.format(EXCEPTION_MESSAGE_FORMAT,
+            dto.serviceName,
+            dto.recruitmentUrl,
+            dto.exception,
+            dto.description);
+    }
+
+    private Mono<List<String>> getNoEventMessage() {
+        return Mono.just(List.of(NO_EVENT));
+    }
+
+    private String getTotalMessage(List<String> list) {
+        return String.join("\n",
+            getHeadLine(),
+            String.join("\n\n", list));
+    }
+
+    record ExceptionCompanyDto (
+        String serviceName,
+        String recruitmentUrl,
+        String exception,
+        String description
+    ) {
+        public static ExceptionCompanyDto of(final ExceptionEvent exceptionEvent, final Company company) {
+            return new ExceptionCompanyDto(company.getServiceName(),
+                                            company.getRecruitmentUrl(),
+                                            exceptionEvent.getException(),
+                                            exceptionEvent.getDescription());
+        }
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/message/JdMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/JdMessageGenerator.java
@@ -1,0 +1,57 @@
+package com.kaispread.grabber.application.message;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+For Example
+[5월 21일 신규 채용 공고] (Daily)
+ - TOSS -
+[토스] 토스 Data 공개채용_Data Analyst [대출사업]
+https://toss.im/career/job-detail?gh_jid=5988626003
+
+ - NAVER LABS -
+[네이버랩스][ALIKE Solution] Computer Vision / 3D Recon. Research Engineer
+https://recruit.navercorp.com/rcrt/view.do?annoId=30002082&lang=ko
+[네이버랩스][ALIKE Solution] Backend engineer
+https://recruit.navercorp.com/rcrt/view.do?annoId=30002082&lang=ko
+*/
+public abstract class JdMessageGenerator {
+
+    // No Event Message
+    protected static final String NO_EVENT = "오늘은 새로운 공고를 찾지 못했습니다";
+
+    // Format
+    private static final String HEAD_LINE = "[%s 신규 채용 공고] (%s)";
+    private static final String TITLE_SERVICE_NAME_FORMAT = "- %s - \n%s";
+    private static final String TITLE_JOB_DESCRIPTION = "[%s] %s \n%s";
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("M월 d일");
+
+    /*
+    * 메시지 첫 줄 문구 생성
+    * ex) [5월 21일 신규 채용 공고] (Daily & Backend & Frontend ..)
+    * */
+    protected String getHeadLine(final String channelName) {
+        String todayDate = LocalDate.now().format(DATE_FORMAT);
+        return String.format(HEAD_LINE, todayDate, channelName);
+    }
+
+    /*
+    * 서비스별 공고 문구 생성
+    * - TOSS -
+    * [토스] 토스 Data 공개채용_Data Analyst [대출사업]
+    * https://toss.im/career/job-detail?gh_jid=5988626003
+    * */
+    protected String getMessageBody(final String serviceName, final List<ScrapJdDto> scrapJdDtoList) {
+        String jobDetails = scrapJdDtoList.stream()
+            .map(jd -> String.format(TITLE_JOB_DESCRIPTION,
+                jd.companyName(),
+                jd.jdTitle(),
+                jd.jdUrl()))
+            .collect(Collectors.joining("\n"));
+        return String.format(TITLE_SERVICE_NAME_FORMAT, serviceName, jobDetails);
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/message/JdMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/JdMessageGenerator.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
+import reactor.core.publisher.Mono;
 
 /*
 For Example
@@ -22,7 +23,7 @@ https://recruit.navercorp.com/rcrt/view.do?annoId=30002082&lang=ko
 public abstract class JdMessageGenerator {
 
     // No Event Message
-    protected static final String NO_EVENT = "오늘은 새로운 공고를 찾지 못했습니다";
+    private static final String NO_EVENT = "오늘은 새로운 공고를 찾지 못했습니다";
 
     // Format
     private static final String HEAD_LINE = "[%s 신규 채용 공고] (%s)";
@@ -45,13 +46,31 @@ public abstract class JdMessageGenerator {
     * [토스] 토스 Data 공개채용_Data Analyst [대출사업]
     * https://toss.im/career/job-detail?gh_jid=5988626003
     * */
-    protected String getMessageBody(final String serviceName, final List<ScrapJdDto> scrapJdDtoList) {
+    protected String getMessagePerService(final String companyName, final List<ScrapJdDto> scrapJdDtoList) {
         String jobDetails = scrapJdDtoList.stream()
             .map(jd -> String.format(TITLE_JOB_DESCRIPTION,
-                jd.companyName(),
+                jd.serviceName(),
                 jd.jdTitle(),
                 jd.jdUrl()))
             .collect(Collectors.joining("\n"));
-        return String.format(TITLE_SERVICE_NAME_FORMAT, serviceName, jobDetails);
+        return String.format(TITLE_SERVICE_NAME_FORMAT, companyName, jobDetails);
+    }
+
+    /*
+    * 새로운 공고가 없을 때 메시지 생성
+    * [5월 21일 신규 채용 공고] (Daily)
+    * 오늘은 새로운 공고를 찾지 못했습니다
+    * */
+    protected Mono<List<String>> getNoEventMessage() {
+        return Mono.just(List.of(NO_EVENT));
+    }
+
+    /*
+    * 헤드라인과 메시지를 합쳐서 반환
+    * */
+    protected String getTotalMessage(final String channelName, final List<String> messagePerCompany) {
+        return String.join("\n",
+            getHeadLine(channelName),
+            String.join("\n\n", messagePerCompany));
     }
 }

--- a/src/main/java/com/kaispread/grabber/application/message/NewEventMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/NewEventMessageGenerator.java
@@ -1,0 +1,9 @@
+package com.kaispread.grabber.application.message;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface NewEventMessageGenerator {
+    Mono<String> generateMessage(Flux<ScrapJdDto> scrapJdDtoFlux);
+}

--- a/src/main/java/com/kaispread/grabber/application/slack/SlackChannel.java
+++ b/src/main/java/com/kaispread/grabber/application/slack/SlackChannel.java
@@ -1,0 +1,17 @@
+package com.kaispread.grabber.application.slack;
+
+import lombok.Getter;
+
+@Getter
+public enum SlackChannel {
+    DAILY_ALL("Daily"),
+    BACKEND("Backend"),
+    FRONTEND("Frontend")
+    ;
+
+    private final String channelName;
+
+    SlackChannel(String channelName) {
+        this.channelName = channelName;
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/slack/SlackNotificationSender.java
+++ b/src/main/java/com/kaispread/grabber/application/slack/SlackNotificationSender.java
@@ -13,4 +13,7 @@ public interface SlackNotificationSender {
 
     @PostExchange(url = "/T073P744H8F/B0743QKC9DG/4kGa3j5TQqtT8PYqEEedcAvk")
     Mono<String> postToTestChannel(@RequestBody SlackMessage message);
+
+    @PostExchange(url = "/T073P744H8F/B074PKVCG3E/ctO4CnQH5B6iPIjugvyuovPv")
+    Mono<String> postToExceptionChannel(@RequestBody SlackMessage message);
 }

--- a/src/main/java/com/kaispread/grabber/domain/company/Company.java
+++ b/src/main/java/com/kaispread/grabber/domain/company/Company.java
@@ -21,16 +21,18 @@ public class Company implements Persistable<String> {
 
     @NotNull private String name;
     @NotNull private String serviceName;
+    @NotNull private String serviceNameKr;
     @NotNull private String recruitmentUrl;
     @NotNull private ScrapperType scrapperType;
 
     @CreatedDate private LocalDateTime createdDate;
 
     @Builder
-    public Company(String id, String name, String serviceName, String recruitmentUrl, ScrapperType scrapperType) {
+    public Company(String id, String name, String serviceName, String serviceNameKr, String recruitmentUrl, ScrapperType scrapperType) {
         this.id = id;
         this.name = name;
         this.serviceName = serviceName;
+        this.serviceNameKr = serviceNameKr;
         this.recruitmentUrl = recruitmentUrl;
         this.scrapperType = scrapperType;
     }

--- a/src/main/java/com/kaispread/grabber/domain/event/ExceptionEvent.java
+++ b/src/main/java/com/kaispread/grabber/domain/event/ExceptionEvent.java
@@ -1,6 +1,7 @@
 package com.kaispread.grabber.domain.event;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,7 +23,7 @@ public class ExceptionEvent {
     private String description;
 
     @NotNull @CreatedDate
-    private LocalDateTime createdDate;
+    private LocalDate createdDate;
 
     @Builder
     public ExceptionEvent(@NotNull String companyId, String exception, String description) {

--- a/src/main/java/com/kaispread/grabber/domain/event/ExceptionEventRepository.java
+++ b/src/main/java/com/kaispread/grabber/domain/event/ExceptionEventRepository.java
@@ -1,6 +1,9 @@
 package com.kaispread.grabber.domain.event;
 
+import java.time.LocalDate;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 public interface ExceptionEventRepository extends ReactiveCrudRepository<ExceptionEvent, Long>  {
+    Flux<ExceptionEvent> findByCreatedDate(LocalDate createdDate);
 }

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `company`
     `id`                char(4)                 NOT NULL COMMENT '회사 ID ex) A001',
     `name`              varchar(255)            NOT NULL COMMENT '회사명',
     `service_name`      varchar(255)            NOT NULL COMMENT '서비스명',
+    `service_name_kr`   varchar(255)            NOT NULL COMMENT '서비스명 (한글)',
     `recruitment_url`   varchar(255)            NOT NULL,
     `scrapper_type`     varchar(100)            NOT NULL,
     `created_date`      DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS `exception_event`
     `company_id`    char(4)                 NOT NULL,
     `exception`     varchar(40)             COMMENT '예외 종류',
     `description`   varchar(255)            COMMENT '예외 설명',
-    `created_date`  DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',
+    `created_date`  DATE DEFAULT NOW()  NOT NULL COMMENT '생성일',
 
     PRIMARY KEY (id)
 );

--- a/src/test/java/com/kaispread/grabber/application/message/DailyJdMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/DailyJdMessageGeneratorTest.java
@@ -1,0 +1,79 @@
+package com.kaispread.grabber.application.message;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class DailyJdMessageGeneratorTest extends IntegrationTestSupport {
+
+    @Autowired
+    @Qualifier("dailyJdMessageGenerator")
+    private NewEventMessageGenerator dailyJdMessageGenerator;
+
+    @DisplayName("새로운 공고 이벤트를 바탕으로 알림 메시지를 생성할 수 있다.")
+    @Test
+    void generateMessage() {
+        // given
+        Flux<ScrapJdDto> events = getMockEvents();
+
+        // when
+        Mono<String> result = dailyJdMessageGenerator.generateMessage(events)
+            .doOnNext(System.out::println);
+
+        // then
+        StepVerifier.create(result)
+            .expectNextMatches(message ->  !message.isBlank())
+            .verifyComplete();
+    }
+
+    @DisplayName("새로운 이벤트가 없을 경우 대체 문구를 생성한다.")
+    @Test
+    void generateMessageNoEvent() {
+        // given
+        Flux<ScrapJdDto> events = Flux.empty();
+
+        // when
+        Mono<String> result = dailyJdMessageGenerator.generateMessage(events)
+            .doOnNext(System.out::println);
+
+        // then
+        StepVerifier.create(result)
+            .expectNextMatches(message ->  message.contains("오늘은 새로운 공고를 찾지 못했습니다"))
+            .verifyComplete();
+    }
+
+    private static Flux<ScrapJdDto> getMockEvents() {
+        return Flux.just(
+            ScrapJdDto.builder()
+                .serviceName("토스")
+                .companyName("Toss")
+                .jdTitle("토스 백엔드 엔지니어 [수신/여신]")
+                .jdUrl("mock.toss.url/1")
+                .build(),
+            ScrapJdDto.builder()
+                .serviceName("토스")
+                .companyName("Toss")
+                .jdTitle("토스 프론트엔드 엔지니어 [수신/여신]")
+                .jdUrl("mock.toss.url/2")
+                .build(),
+            ScrapJdDto.builder()
+                .serviceName("네이버웹툰")
+                .companyName("Naver")
+                .jdTitle("네이버웹툰 Backend developer [결제]")
+                .jdUrl("mock.naver.url/1")
+                .build(),
+            ScrapJdDto.builder()
+                .serviceName("Hakuna")
+                .companyName("Hyperconnect")
+                .jdTitle("Hakuna Backend engineer")
+                .jdUrl("mock.hyperconnect.url/1")
+                .build()
+        );
+    }
+}

--- a/src/test/java/com/kaispread/grabber/application/message/ExceptionEventMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/ExceptionEventMessageGeneratorTest.java
@@ -1,0 +1,97 @@
+package com.kaispread.grabber.application.message;
+
+import com.kaispread.grabber.application.scrap.ScrapperType;
+import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import com.kaispread.grabber.domain.company.Company;
+import com.kaispread.grabber.domain.company.CompanyRepository;
+import com.kaispread.grabber.domain.event.ExceptionEvent;
+import com.kaispread.grabber.domain.event.ExceptionEventRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ExceptionEventMessageGeneratorTest extends IntegrationTestSupport {
+
+    @Autowired
+    ExceptionEventMessageGenerator exceptionEventMessageGenerator;
+
+    @Autowired
+    ExceptionEventRepository exceptionEventRepository;
+
+    @Autowired
+    CompanyRepository companyRepository;
+
+    @BeforeEach
+    void setUp() {
+        companyRepository.save(Company.builder()
+                .id("A001")
+                .name("Kakao")
+                .serviceName("kakao talk")
+                .serviceNameKr("카카오톡")
+                .recruitmentUrl("mock.kakao.url")
+                .scrapperType(ScrapperType.KAKAO_CORE)
+            .build()).block();
+
+        companyRepository.save(Company.builder()
+            .id("A002")
+            .name("Hyperconnect")
+            .serviceName("Azar")
+            .serviceNameKr("아자르")
+            .recruitmentUrl("mock.azar.url")
+            .scrapperType(ScrapperType.HYPERCONNECT)
+            .build()).block();
+
+        exceptionEventRepository.save(
+            ExceptionEvent.builder()
+                .companyId("A001")
+                .exception("NullPointException")
+                .description("널일 수 없습니다")
+                .build()).block();
+
+        exceptionEventRepository.save(
+            ExceptionEvent.builder()
+                .companyId("A002")
+                .exception("IllegalArgumentException")
+                .description("유효하지 않은 값입니다.")
+                .build()).block();
+    }
+
+    @AfterEach
+    void tearDown() {
+        exceptionEventRepository.deleteAll().block();
+        companyRepository.deleteAll().block();
+    }
+
+    @DisplayName("예외 메시지를 생성할 수 있다.")
+    @Test
+    void generateMessage() {
+        // when
+        Mono<String> exceptionMessage = exceptionEventMessageGenerator.generateExceptionMessage()
+            .doOnNext(System.out::println);
+
+        // then
+        StepVerifier.create(exceptionMessage)
+            .expectNextMatches(message -> !message.isBlank())
+            .verifyComplete();
+    }
+
+    @DisplayName("예외가 발생하지 않았을 경우 대체 메시지를 반환한다.")
+    @Test
+    void generateMessage_with_no_event() {
+        // given
+        exceptionEventRepository.deleteAll().block();
+
+        // when
+        Mono<String> exceptionMessage = exceptionEventMessageGenerator.generateExceptionMessage()
+            .doOnNext(System.out::println);
+
+        // then
+        StepVerifier.create(exceptionMessage)
+            .expectNextMatches(message -> message.contains("* 아무 예외가 발생하지 않았습니다 *"))
+            .verifyComplete();
+    }
+}

--- a/src/test/java/com/kaispread/grabber/application/message/JdMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/JdMessageGeneratorTest.java
@@ -25,14 +25,14 @@ class JdMessageGeneratorTest {
 
     @DisplayName("서비스별 공고 문구를 생성할 수 있다.")
     @Test
-    void getMessageBody() {
+    void getMessagePerService() {
         // given
         MockJdMessageGenerator messageGenerator = new MockJdMessageGenerator();
         String serviceName = "Toss";
         List<ScrapJdDto> serviceScrapList = getServiceScrapList();
 
         // when
-        String messageBody = messageGenerator.getMessageBody(serviceName, serviceScrapList);
+        String messageBody = messageGenerator.getMessagePerService(serviceName, serviceScrapList);
 
         // then
         System.out.println(messageBody);

--- a/src/test/java/com/kaispread/grabber/application/message/JdMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/JdMessageGeneratorTest.java
@@ -1,0 +1,61 @@
+package com.kaispread.grabber.application.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JdMessageGeneratorTest {
+
+    @DisplayName("첫 줄 문구를 가져올 수 있다.")
+    @Test
+    void getHeadLine() {
+        // given
+        MockJdMessageGenerator messageGenerator = new MockJdMessageGenerator();
+
+        // when
+        String result = messageGenerator.getHeadLine("Daily");
+
+        // then
+        System.out.println(result);
+        assertThat(result).isNotBlank();
+    }
+
+    @DisplayName("서비스별 공고 문구를 생성할 수 있다.")
+    @Test
+    void getMessageBody() {
+        // given
+        MockJdMessageGenerator messageGenerator = new MockJdMessageGenerator();
+        String serviceName = "Toss";
+        List<ScrapJdDto> serviceScrapList = getServiceScrapList();
+
+        // when
+        String messageBody = messageGenerator.getMessageBody(serviceName, serviceScrapList);
+
+        // then
+        System.out.println(messageBody);
+        assertThat(messageBody).isNotBlank();
+    }
+
+    private static List<ScrapJdDto> getServiceScrapList() {
+        return List.of(ScrapJdDto.builder()
+                .companyId("A001")
+                .companyName("Toss")
+                .jdTitle("백엔드 엔지니어")
+                .jdUrl("mock.url.com/1")
+                .jdId("JE001")
+                .build(),
+            ScrapJdDto.builder()
+                .companyId("A001")
+                .companyName("Toss")
+                .jdTitle("프론트엔드 엔지니어")
+                .jdUrl("mock.url.com/2")
+                .jdId("JE002")
+                .build());
+    }
+
+    static class MockJdMessageGenerator extends JdMessageGenerator {
+    }
+}

--- a/src/test/java/com/kaispread/grabber/domain/event/ExceptionEventRepositoryTest.java
+++ b/src/test/java/com/kaispread/grabber/domain/event/ExceptionEventRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.kaispread.grabber.domain.event;
+
+import com.kaispread.grabber.base.support.IntegrationTestSupport;
+import java.time.LocalDate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+class ExceptionEventRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ExceptionEventRepository exceptionEventRepository;
+
+    @BeforeEach
+    void setUp() {
+        exceptionEventRepository.save(ExceptionEvent.builder()
+            .exception("NullPointException")
+            .description("널이 아니여아합니다.")
+            .companyId("A001")
+            .build()).block();
+    }
+
+    @AfterEach
+    void tearDown() {
+        exceptionEventRepository.deleteAll().block();
+    }
+
+    @DisplayName("날짜를 기준으로 데이터를 조회할 수 있다.")
+    @Test
+    void findByCreatedDate() {
+        // given
+        LocalDate time = LocalDate.now();
+
+        // when
+        Flux<ExceptionEvent> findedFlux = exceptionEventRepository.findByCreatedDate(time);
+
+        // then
+        StepVerifier.create(findedFlux)
+            .expectNextMatches(data -> data.getCompanyId().equals("A001"))
+            .verifyComplete();
+    }
+}

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `company`
     `id`                char(4)                 NOT NULL COMMENT '회사 ID ex) A001',
     `name`              varchar(255)            NOT NULL COMMENT '회사명',
     `service_name`      varchar(255)            NOT NULL COMMENT '서비스명',
+    `service_name_kr`   varchar(255)            NOT NULL COMMENT '서비스명 (한글)',
     `recruitment_url`   varchar(255)            NOT NULL,
     `scrapper_type`     varchar(100)            NOT NULL,
     `created_date`      DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS `exception_event`
     `company_id`    char(4)                 NOT NULL,
     `exception`     varchar(40)             COMMENT '예외 종류',
     `description`   varchar(255)            COMMENT '예외 설명',
-    `created_date`  DATETIME DEFAULT NOW()  NOT NULL COMMENT '생성일',
+    `created_date`  DATE DEFAULT NOW()  NOT NULL COMMENT '생성일',
 
     PRIMARY KEY (id)
 );


### PR DESCRIPTION
## Related Issue
#11 
## Description
- 오늘 날짜를 기준으로 예외 이벤트를 조회하여 메시지를 생성하는 클래스 추가
- ExceptionEvent 날짜 컬럼 데이터 타입 변경 (LocalDateTime -> LocalDate)

## Tasks not included in this PR
- slack 알림 전송 기능

## What to do in the future
- slack 알림 전송 기능 추가
- 스크래퍼 -> 메시지 생성 -> 알림 전송 연동
