### PR TITLE
feat: 스크래핑 & 메시지 생성 및 알림 전송 기능 통합

### DIFF
--- a/src/main/java/com/kaispread/grabber/application/message/generator/DailyJdMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/generator/DailyJdMessageGenerator.java
@@ -1,4 +1,4 @@
-package com.kaispread.grabber.application.message;
+package com.kaispread.grabber.application.message.generator;
 
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import com.kaispread.grabber.application.slack.SlackChannel;

--- a/src/main/java/com/kaispread/grabber/application/message/generator/ExceptionEventMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/generator/ExceptionEventMessageGenerator.java
@@ -1,4 +1,4 @@
-package com.kaispread.grabber.application.message;
+package com.kaispread.grabber.application.message.generator;
 
 import com.kaispread.grabber.domain.company.Company;
 import com.kaispread.grabber.domain.company.CompanyRepository;

--- a/src/main/java/com/kaispread/grabber/application/message/generator/JdMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/generator/JdMessageGenerator.java
@@ -1,4 +1,4 @@
-package com.kaispread.grabber.application.message;
+package com.kaispread.grabber.application.message.generator;
 
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import java.time.LocalDate;

--- a/src/main/java/com/kaispread/grabber/application/message/generator/NewEventMessageGenerator.java
+++ b/src/main/java/com/kaispread/grabber/application/message/generator/NewEventMessageGenerator.java
@@ -1,4 +1,4 @@
-package com.kaispread.grabber.application.message;
+package com.kaispread.grabber.application.message.generator;
 
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
 import reactor.core.publisher.Flux;

--- a/src/main/java/com/kaispread/grabber/application/message/sender/DailyMessageSender.java
+++ b/src/main/java/com/kaispread/grabber/application/message/sender/DailyMessageSender.java
@@ -1,0 +1,32 @@
+package com.kaispread.grabber.application.message.sender;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.message.generator.NewEventMessageGenerator;
+import com.kaispread.grabber.application.slack.SlackMessage;
+import com.kaispread.grabber.application.slack.SlackNotificationSender;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+public class DailyMessageSender implements MessageSender {
+
+    private final SlackNotificationSender slackNotificationSender;
+    private final NewEventMessageGenerator newEventMessageGenerator;
+
+    public DailyMessageSender(@Qualifier("dailyJdMessageGenerator") NewEventMessageGenerator newEventMessageGenerator,
+                              SlackNotificationSender slackNotificationSender) {
+        this.slackNotificationSender = slackNotificationSender;
+        this.newEventMessageGenerator = newEventMessageGenerator;
+    }
+
+    @Override
+    public Mono<Void> send(final Flux<ScrapJdDto> scrapJdDtoFlux) {
+        return newEventMessageGenerator.generateMessage(scrapJdDtoFlux)
+            .map(SlackMessage::new)
+            // 새로운 공고 알림 전송
+            .flatMap(slackNotificationSender::postToDailyChannel)
+            .then();
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/message/sender/DefaultExceptionMessageSender.java
+++ b/src/main/java/com/kaispread/grabber/application/message/sender/DefaultExceptionMessageSender.java
@@ -1,0 +1,28 @@
+package com.kaispread.grabber.application.message.sender;
+
+import com.kaispread.grabber.application.message.generator.ExceptionEventMessageGenerator;
+import com.kaispread.grabber.application.slack.SlackMessage;
+import com.kaispread.grabber.application.slack.SlackNotificationSender;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class DefaultExceptionMessageSender implements ExceptionMessageSender {
+
+    private final SlackNotificationSender slackNotificationSender;
+    private final ExceptionEventMessageGenerator exceptionEventMessageGenerator;
+
+    public DefaultExceptionMessageSender(SlackNotificationSender slackNotificationSender,
+                                    ExceptionEventMessageGenerator exceptionEventMessageGenerator) {
+        this.slackNotificationSender = slackNotificationSender;
+        this.exceptionEventMessageGenerator = exceptionEventMessageGenerator;
+    }
+
+    @Override
+    public Mono<Void> send() {
+        return exceptionEventMessageGenerator.generateExceptionMessage()
+            .map(SlackMessage::new)
+            .flatMap(slackNotificationSender::postToExceptionChannel)
+            .then();
+    }
+}

--- a/src/main/java/com/kaispread/grabber/application/message/sender/ExceptionMessageSender.java
+++ b/src/main/java/com/kaispread/grabber/application/message/sender/ExceptionMessageSender.java
@@ -1,0 +1,7 @@
+package com.kaispread.grabber.application.message.sender;
+
+import reactor.core.publisher.Mono;
+
+public interface ExceptionMessageSender {
+    Mono<Void> send();
+}

--- a/src/main/java/com/kaispread/grabber/application/message/sender/MessageSender.java
+++ b/src/main/java/com/kaispread/grabber/application/message/sender/MessageSender.java
@@ -1,0 +1,9 @@
+package com.kaispread.grabber.application.message.sender;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface MessageSender {
+    Mono<Void> send(Flux<ScrapJdDto> scrapJdDtoFlux);
+}

--- a/src/main/java/com/kaispread/grabber/application/service/ScrapNotificationSender.java
+++ b/src/main/java/com/kaispread/grabber/application/service/ScrapNotificationSender.java
@@ -1,0 +1,33 @@
+package com.kaispread.grabber.application.service;
+
+import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.message.sender.ExceptionMessageSender;
+import com.kaispread.grabber.application.message.sender.MessageSender;
+import com.kaispread.grabber.application.scrap.core.MainScrapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class ScrapNotificationSender {
+
+    private final MainScrapper mainScrapper;
+    private final ExceptionMessageSender exceptionMessageSender;
+    private final MessageSender dailyMessageSender;
+
+    public ScrapNotificationSender(MainScrapper mainScrapper,
+                                   ExceptionMessageSender exceptionMessageSender,
+                                   @Qualifier("dailyMessageSender") MessageSender dailyMessageSender) {
+        this.mainScrapper = mainScrapper;
+        this.exceptionMessageSender = exceptionMessageSender;
+        this.dailyMessageSender = dailyMessageSender;
+    }
+
+    public Mono<Void> scrapAndSend() {
+        Flux<ScrapJdDto> scrapJdDtoFlux = mainScrapper.runScrapping();
+
+        return dailyMessageSender.send(scrapJdDtoFlux)
+            .then(exceptionMessageSender.send());
+    }
+}

--- a/src/main/java/com/kaispread/grabber/presentation/ScrapperController.java
+++ b/src/main/java/com/kaispread/grabber/presentation/ScrapperController.java
@@ -1,6 +1,6 @@
 package com.kaispread.grabber.presentation;
 
-import com.kaispread.grabber.application.scrap.core.MainScrapper;
+import com.kaispread.grabber.application.service.ScrapNotificationSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,11 +11,10 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/v1/scrap")
 @RestController
 public class ScrapperController {
-    private final MainScrapper mainScrapper;
+    private final ScrapNotificationSender scrapNotificationSender;
 
     @PostMapping
     public Mono<Void> post() {
-        return mainScrapper.runScrapping()
-                           .then();
+        return scrapNotificationSender.scrapAndSend();
     }
 }

--- a/src/test/java/com/kaispread/grabber/application/message/DailyJdMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/DailyJdMessageGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.kaispread.grabber.application.message;
 
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.message.generator.NewEventMessageGenerator;
 import com.kaispread.grabber.base.support.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/kaispread/grabber/application/message/ExceptionEventMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/ExceptionEventMessageGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.kaispread.grabber.application.message;
 
+import com.kaispread.grabber.application.message.generator.ExceptionEventMessageGenerator;
 import com.kaispread.grabber.application.scrap.ScrapperType;
 import com.kaispread.grabber.base.support.IntegrationTestSupport;
 import com.kaispread.grabber.domain.company.Company;

--- a/src/test/java/com/kaispread/grabber/application/message/JdMessageGeneratorTest.java
+++ b/src/test/java/com/kaispread/grabber/application/message/JdMessageGeneratorTest.java
@@ -3,6 +3,7 @@ package com.kaispread.grabber.application.message;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.kaispread.grabber.application.dto.scrap.ScrapJdDto;
+import com.kaispread.grabber.application.message.generator.JdMessageGenerator;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ class JdMessageGeneratorTest {
         MockJdMessageGenerator messageGenerator = new MockJdMessageGenerator();
 
         // when
-        String result = messageGenerator.getHeadLine("Daily");
+        String result = messageGenerator.mockGetHeadLine("Daily");
 
         // then
         System.out.println(result);
@@ -32,7 +33,7 @@ class JdMessageGeneratorTest {
         List<ScrapJdDto> serviceScrapList = getServiceScrapList();
 
         // when
-        String messageBody = messageGenerator.getMessagePerService(serviceName, serviceScrapList);
+        String messageBody = messageGenerator.mockGetMessagePerService(serviceName, serviceScrapList);
 
         // then
         System.out.println(messageBody);
@@ -57,5 +58,12 @@ class JdMessageGeneratorTest {
     }
 
     static class MockJdMessageGenerator extends JdMessageGenerator {
+        public String mockGetHeadLine(String channelName) {
+            return getHeadLine(channelName);
+        }
+
+        public String mockGetMessagePerService(String companyName, List<ScrapJdDto> serviceScrapList) {
+            return getMessagePerService(companyName, serviceScrapList);
+        }
     }
 }

--- a/src/test/java/com/kaispread/grabber/domain/company/CompanyRepositoryTest.java
+++ b/src/test/java/com/kaispread/grabber/domain/company/CompanyRepositoryTest.java
@@ -27,8 +27,9 @@ class CompanyRepositoryTest extends IntegrationTestSupport {
         // given
         Company company = Company.builder()
             .id("A001")
-            .name("카카오")
-            .serviceName("카카오코어")
+            .name("kakao")
+            .serviceName("kakao core")
+            .serviceNameKr("카카오 코어")
             .recruitmentUrl("test.url")
             .scrapperType(KAKAO_CORE)
             .build();
@@ -43,7 +44,7 @@ class CompanyRepositoryTest extends IntegrationTestSupport {
 
         Flux<Company> allCompanies = repository.findAll();
         StepVerifier.create(allCompanies)
-            .expectNextMatches(savedCompany -> savedCompany.getName().equals("카카오"))
+            .expectNextMatches(savedCompany -> savedCompany.getName().equals("kakao"))
             .verifyComplete();
     }
 }

--- a/src/test/java/com/kaispread/grabber/domain/jd/JobDescriptionRepositoryTest.java
+++ b/src/test/java/com/kaispread/grabber/domain/jd/JobDescriptionRepositoryTest.java
@@ -49,6 +49,7 @@ class JobDescriptionRepositoryTest extends IntegrationTestSupport {
                 .id("A001")
                 .name("kakao")
                 .serviceName("kakao core")
+                .serviceNameKr("카카오 코어")
                 .recruitmentUrl("mock.url")
                 .scrapperType(ScrapperType.KAKAO_CORE)
                 .build());


### PR DESCRIPTION
## Related Issue
#11 
## Description
- 스크래퍼 -> 메시지 생성 -> 알림 전송 연동
- 스크래퍼와 알림 전송 기능을 통합한 facade 클래스 추가 (ScrapNotificationSender)

## Tasks not included in this PR

## What to do in the future
- 스케줄러 기능 추가
- 다른 회사 공고 스크래퍼 추가